### PR TITLE
Updated Mockery/Mockery to version ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,11 @@
         "convert-xml",
         "fetchleo"
     ],
-    "authors": [
-        {
-            "name": "Leo Smith",
-            "email": "leodoesmc1@gmail.com",
-            "role": "Maintainer"
-        }
-    ],
+    "authors": [{
+        "name": "Leo Smith",
+        "email": "leodoesmc1@gmail.com",
+        "role": "Maintainer"
+    }],
     "autoload": {
         "psr-0": {
             "FetchLeo\\LaravelXml\\": "src/"
@@ -33,6 +31,6 @@
         "illuminate/support": "^5.2",
         "illuminate/database": "^5.2",
         "orchestra/testbench": "~3.0",
-        "mockery/mockery": "~0.9"
+        "mockery/mockery": "^1.0"
     }
 }


### PR DESCRIPTION
When trying to use fetchleo/laravel-xml with Laravel 5.6 I ran into an inmcompatibility with mockery (~0.9 vs ^1.0).